### PR TITLE
fix: Spelling mistake in testing script

### DIFF
--- a/test/test_powerpal_api.py
+++ b/test/test_powerpal_api.py
@@ -55,7 +55,7 @@ async def test_authorization_error():
     with aioresponses() as m:
         m.get(
             f'https://readings.powerpal.net/api/v1/device/{EXAMPLE_DEVICE_ID}',
-            status=403, body="Authentication Error")
+            status=403, body="Authorization Error")
 
         session = ClientSession()
         powerpal = Powerpal(session, EXAMPLE_AUTH_STR, EXAMPLE_DEVICE_ID)


### PR DESCRIPTION
I was going through the codes and would like to contribute by adding a method to get historical readings from Powerpal API. This is just the first PR trying to fix a spelling mistake when reviewing the code.